### PR TITLE
BF-58 write daily log by spdlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ $ sudo apt-get install -y \
     libhiredis-dev \
     libmysqlcppconn-dev \
     rapidjson-dev \
-    libasio-dev
+    libasio-dev \
+    libspdlog-dev
 
 # Set timezone (optional)
 $ sudo timedatectl set-timezone Asia/Ho_Chi_Minh

--- a/botfather_c++/CMakeLists.txt
+++ b/botfather_c++/CMakeLists.txt
@@ -27,14 +27,26 @@ endif()
 
 option(DEBUG_LOG "Enable debug mode" OFF)
 if(DEBUG_LOG)
+    message(STATUS "Enable debug mode ON")
     add_definitions(-DDEBUG_LOG)
+else()
+    message(STATUS "Enable debug mode OFF")
+endif()
+
+option(LOG_FILE "Enable log file mode" OFF)
+if(LOG_FILE)
+    message(STATUS "Enable log file mode ON")
+    add_definitions(-DLOG_FILE)
+else()
+    message(STATUS "Enable log file mode OFF")
 endif()
 
 #include lib
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(OpenSSL REQUIRED)
-
-find_library(ANTLR4_LIB antlr4-runtime REQUIRED)
+find_package(spdlog REQUIRED)
+find_library(
+    ANTLR4_LIB antlr4-runtime REQUIRED)
 find_library(SIOCLIENT_LIB sioclient REQUIRED)
 find_library(SIOCLIENT_TLS_LIB sioclient_tls REQUIRED)
 
@@ -53,6 +65,7 @@ target_link_libraries(botfather
     tbb
     -lhiredis
     mysqlcppconn
+    spdlog::spdlog
     ${ANTLR4_LIB}
     ${SIOCLIENT_LIB}
     ${SIOCLIENT_TLS_LIB}

--- a/botfather_c++/build.sh
+++ b/botfather_c++/build.sh
@@ -12,5 +12,5 @@ cd "$SCRIPT_DIR"
 rm -rf build
 mkdir build
 
-cmake -S ./ -B ./build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake -S ./ -B ./build -G Ninja -DCMAKE_BUILD_TYPE=Release -DLOG_FILE=ON
 cmake --build ./build -- -j $(nproc)

--- a/botfather_c++/include/common/common_type.h
+++ b/botfather_c++/include/common/common_type.h
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <functional>
 #include <any>
+#include <filesystem>
 
 #include <websocketpp/config/asio_client.hpp>
 #include <websocketpp/client.hpp>
@@ -27,36 +28,24 @@
 #include <boost/asio/ssl.hpp>
 #include <nlohmann/json.hpp>
 
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <fmt/format.h>
+#include <fmt/core.h>
+
 using namespace std;
 
 // #define DEBUG_LOG 1
 
-inline string current_timestamp()
-{
-    auto now = chrono::system_clock::now();
-    auto now_t = chrono::system_clock::to_time_t(now);
-    tm local_tm = *localtime(&now_t);
-
-    ostringstream oss;
-    oss << put_time(&local_tm, "%Y-%m-%d %H:%M:%S");
-    return oss.str();
-}
-
-inline string current_thread_id()
-{
-    ostringstream oss;
-    oss << this_thread::get_id();
-    return oss.str();
-}
-
 #ifndef DEBUG_LOG
 #define LOGD(mess, ...)
 #else
-#define LOGD(mess, ...) printf("[%s] [%s] [DEBUG] [%s] " mess "\n", current_thread_id().c_str(), current_timestamp().c_str(), __func__, ##__VA_ARGS__);
+#define LOGD(mess, ...) spdlog::debug("[{}] {}", __func__, fmt::format(mess, ##__VA_ARGS__))
 #endif
 
-#define LOGI(mess, ...) printf("[%s] [%s] [INFO] [%s] " mess "\n", current_thread_id().c_str(), current_timestamp().c_str(), __func__, ##__VA_ARGS__);
-#define LOGE(mess, ...) fprintf(stderr, "[%s] [%s] [ERROR] [%s] " mess "\n", current_thread_id().c_str(), current_timestamp().c_str(), __func__, ##__VA_ARGS__);
+#define LOGI(mess, ...) spdlog::info("[{}] {}", __func__, fmt::format(mess, ##__VA_ARGS__))
+#define LOGE(mess, ...) spdlog::error("[{}] {}", __func__, fmt::format(mess, ##__VA_ARGS__))
 
 #define SLEEP_FOR(ms) this_thread::sleep_for(chrono::milliseconds(ms))
 

--- a/botfather_c++/include/common/timer.h
+++ b/botfather_c++/include/common/timer.h
@@ -14,7 +14,7 @@ public:
         auto end = std::chrono::high_resolution_clock::now();
         auto duration = end - start_;
         long long ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-        LOGI("%s: %lld ms", name_.c_str(), ms);
+        LOGI("{}: {} ms", name_, ms);
     }
 
 private:

--- a/botfather_c++/include/common/util.h
+++ b/botfather_c++/include/common/util.h
@@ -15,8 +15,15 @@ long long getCurrentTime();
 unordered_map<string, string> readEnvFile();
 vector<string> split(const string &s, char delimiter);
 vector<string> convertJsonStringArrayToVector(string s);
-string StringFormat(const char *format, ...);
 string doubleToString(double value, int precision);
+
+// template must define in header file
+template <typename... Args>
+string StringFormat(const string &format, Args &&...args)
+{
+    return fmt::format(format, forward<Args>(args)...);
+}
+
 
 RateData getBinanceOHLCV(const string &symbol, const string &timeframe, int limit, long long since = 0);
 RateData getBinanceFuturetOHLCV(const string &symbol, const string &timeframe, int limit, long long since = 0);

--- a/botfather_c++/main.cpp
+++ b/botfather_c++/main.cpp
@@ -9,6 +9,39 @@ using namespace std;
 
 void init()
 {
+#ifdef LOG_FILE
+    printf("Write log to file\n");
+    char exePath[PATH_MAX];
+    ssize_t len = readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
+    if (len == -1)
+    {
+        std::cerr << "readlink failed\n";
+        throw "readlink failed";
+    }
+    exePath[len] = '\0';
+    std::filesystem::path exeDir = std::filesystem::path(exePath).parent_path();
+    std::filesystem::path logDir = (exeDir / ".." / "logs").lexically_normal();
+    std::filesystem::create_directories(logDir);
+
+    std::string logFilePath = (logDir / "botfather.log").string();
+    auto logger = spdlog::daily_logger_mt(
+        "botfather_daily_logger", // tên logger
+        logFilePath,              // file log
+        0, 0,                     // 00:00 mỗi ngày
+        false,                    // không ghi đè
+        7                         // giữ 7 file
+    );
+    spdlog::set_default_logger(logger);
+#else
+    printf("Write log to console\n");
+    auto logger = spdlog::stdout_color_mt("console");
+    spdlog::set_default_logger(logger);
+#endif
+
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%t] [%^%l%$] %v");
+    spdlog::set_level(spdlog::level::debug);
+    spdlog::flush_on(spdlog::level::info);
+
     MySQLConnector::getInstance();
     Telegram::getInstance();
     startOrderMonitor();
@@ -26,7 +59,7 @@ int main()
     auto now = std::chrono::system_clock::now();
     auto duration = now.time_since_epoch();
     long long milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-    LOGI("Hello BotFather! %s", toTimeString(milliseconds).c_str());
+    LOGI("Hello BotFather! {}", toTimeString(milliseconds));
 
     init();
     runApp();

--- a/botfather_c++/src/botfather.cpp
+++ b/botfather_c++/src/botfather.cpp
@@ -28,7 +28,7 @@ void test()
     const string API_KEY = env["API_KEY"];
     const string SECRET_KEY = env["SECRET_KEY"];
 
-    LOGD("SECRET_KEY: %s", SECRET_KEY.c_str());
+    LOGD("SECRET_KEY: {}", SECRET_KEY);
 
     shared_ptr<BinanceFuture> exchange = make_shared<BinanceFuture>(API_KEY, SECRET_KEY);
     exchange->buyLimit("BTCUSDT", "0.01", "100000", "101000", "99000", to_string(getCurrentTime() + 60000 * 15));
@@ -195,7 +195,7 @@ void sio_on_message(string const &event, sio::message::ptr const &data, bool isA
     if (event == "onUpdateConfig")
     {
         string botName = data->get_string();
-        LOGI("Update config for bot %s", botName.c_str());
+        LOGI("Update config for bot {}", botName);
         setBotList(botName);
     }
 }
@@ -225,7 +225,7 @@ void runApp()
     // connect socket_io to web config
     client.set_open_listener(sio_on_connected);
     client.socket()->on("onUpdateConfig", sio_on_message);
-    client.connect(StringFormat("%s:%d", env["HOST_WEB_SERVER"].c_str(), 8080));
+    client.connect(StringFormat("{}:{}", env["HOST_WEB_SERVER"], 8080));
 
     for (auto &t : threads)
     {

--- a/botfather_c++/src/common/axios.cpp
+++ b/botfather_c++/src/common/axios.cpp
@@ -50,7 +50,7 @@ string Axios::get(const string &url, const vector<string> &headers)
     if (res && res->status == 200)
         return res->body;
 
-    LOGE("[request] GET request failed: %s. body=%s, url=%s", res ? res->reason.c_str() : "No response", res ? res->body.c_str() : "", url.c_str());
+    LOGE("[request] GET request failed: {}. body={}, url={}", res ? res->reason : "No response", res ? res->body : "", url);
     throw runtime_error("GET request failed.");
 }
 
@@ -67,7 +67,7 @@ string Axios::post(const string &url, const string &body,
     if (res && res->status == 200)
         return res->body;
 
-    LOGE("[request] POST request failed: reason: %s. body: %s. url=%s", res ? res->reason.c_str() : "No response", res ? res->body.c_str() : "", url.c_str());
+    LOGE("[request] POST request failed: reason: {}. body: {}. url={}", res ? res->reason : "No response", res ? res->body : "", url);
     throw runtime_error("POST request failed.");
 }
 
@@ -84,7 +84,7 @@ string Axios::put(const string &url, const string &body,
     if (res && res->status == 200)
         return res->body;
 
-    LOGE("[request] PUT request failed: %s. url=%s", res ? res->reason.c_str() : "No response", url.c_str());
+    LOGE("[request] PUT request failed: {}. url={}", res ? res->reason : "No response", url);
     throw runtime_error("PUT request failed.");
 }
 
@@ -100,6 +100,6 @@ string Axios::del(const string &url, const vector<string> &headers)
     if (res && res->status == 200)
         return res->body;
 
-    LOGE("[request] DELETE request failed: %s. body=%s, url=%s", res ? res->reason.c_str() : "No response", res ? res->body.c_str() : "", url.c_str());
+    LOGE("[request] DELETE request failed: {}. body={}, url={}", res ? res->reason : "No response", res ? res->body : "", url);
     throw runtime_error("DELETE request failed.");
 }

--- a/botfather_c++/src/common/expr.cpp
+++ b/botfather_c++/src/common/expr.cpp
@@ -1022,7 +1022,7 @@ string calculateSubExpr(string &expr, const string &broker, const string &symbol
         {
             if (st.size() == 0 || s == "")
             {
-                LOGE("Invalid expr %s", expr.c_str());
+                LOGE("Invalid expr {}", expr);
                 return "";
             }
             string lastS = st.top();
@@ -1043,7 +1043,7 @@ string calculateSubExpr(string &expr, const string &broker, const string &symbol
             }
             else
             {
-                LOGE("Invalid result type %s for expr %s", result.type().name(), expr.c_str());
+                LOGE("Invalid result type {} for expr {}", result.type().name(), expr);
                 return "";
             }
         }
@@ -1054,7 +1054,7 @@ string calculateSubExpr(string &expr, const string &broker, const string &symbol
     }
     if (st.size() > 1)
     {
-        LOGE("Invalid expr %s", expr.c_str());
+        LOGE("Invalid expr {}", expr);
         return "";
     }
     return (st.size() == 0 ? "" : st.top()) + s;

--- a/botfather_c++/src/common/redis.cpp
+++ b/botfather_c++/src/common/redis.cpp
@@ -28,7 +28,7 @@ bool Redis::connect(const string &host, int port, const string &password)
     {
         if (context)
         {
-            LOGE("Redis error: %s", context->errstr);
+            LOGE("Redis error: {}", context->errstr);
             redisFree(context);
             context = nullptr;
         }
@@ -45,7 +45,7 @@ bool Redis::connect(const string &host, int port, const string &password)
         redisReply *reply = (redisReply *)redisCommand(context, "AUTH %s", password.c_str());
         if (reply->type == REDIS_REPLY_ERROR)
         {
-            LOGE("Redis authentication failed: %s", reply->str);
+            LOGE("Redis authentication failed: {}", reply->str);
             freeReplyObject(reply);
             redisFree(context);
             context = nullptr;
@@ -54,7 +54,7 @@ bool Redis::connect(const string &host, int port, const string &password)
         freeReplyObject(reply);
     }
 
-    LOGI("Redis connected to %s:%d", host.c_str(), port);
+    LOGI("Redis connected to {}:{}", host, port);
     return true;
 }
 

--- a/botfather_c++/src/common/telegram.cpp
+++ b/botfather_c++/src/common/telegram.cpp
@@ -44,8 +44,8 @@ Telegram &Telegram::getInstance()
 
 bool Telegram::sendMessageInternal(const string &message, const string &chatId)
 {
-    string url = StringFormat("https://api.telegram.org/bot%s/sendMessage?chat_id=%s&text=%s&parse_mode=HTML&disable_web_page_preview=true",
-                              botToken.c_str(), urlEncode(chatId).c_str(), urlEncode(message).c_str());
+    string url = StringFormat("https://api.telegram.org/bot{}/sendMessage?chat_id={}&text={}&parse_mode=HTML&disable_web_page_preview=true",
+                              botToken, urlEncode(chatId), urlEncode(message));
 
     try
     {
@@ -54,7 +54,7 @@ bool Telegram::sendMessageInternal(const string &message, const string &chatId)
     }
     catch (const exception &e)
     {
-        LOGE("Failed to send Telegram message: %s. message=%s", e.what(), message.c_str());
+        LOGE("Failed to send Telegram message: {}. message={}", e.what(), message);
         return false;
     }
 }
@@ -117,7 +117,7 @@ void Telegram::debounceWorker(const string &chatId, shared_ptr<ChatBuffer> buffe
 
 void Telegram::sendMessage(const string &message, const string &chatId)
 {
-    LOGI("Sending Telegram message to chat %s: %s", chatId.c_str(), message.c_str());
+    LOGI("Sending Telegram message to chat {}: {}", chatId, message);
     shared_ptr<ChatBuffer> buffer;
 
     {

--- a/botfather_c++/src/common/util.cpp
+++ b/botfather_c++/src/common/util.cpp
@@ -237,38 +237,10 @@ vector<string> convertJsonStringArrayToVector(string s)
         }
         else
         {
-            LOGE("Invalid item in JSON array: %s", item.dump().c_str());
+            LOGE("Invalid item in JSON array: {}", item.dump());
         }
     }
     return result;
-}
-
-string StringFormat(const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-
-    // tạo buffer tạm lớn
-    vector<char> buffer(1024);
-    int needed = vsnprintf(buffer.data(), buffer.size(), format, args);
-    va_end(args);
-
-    if (needed < 0)
-        return "";
-
-    if (static_cast<size_t>(needed) < buffer.size())
-    {
-        return string(buffer.data());
-    }
-    else
-    {
-        // nếu buffer chưa đủ lớn, cấp lại
-        buffer.resize(needed + 1);
-        va_start(args, format);
-        vsnprintf(buffer.data(), buffer.size(), format, args);
-        va_end(args);
-        return string(buffer.data());
-    }
 }
 
 string doubleToString(double value, int precision)
@@ -349,9 +321,9 @@ RateData getBybitFutureOHLCV(const string &symbol, const string &timeframe, int 
         tf = "D";
     }
 
-    string url = StringFormat("https://api.bybit.com/v5/market/kline?category=linear&symbol=%s&interval=%s&limit=%d", symbol.c_str(), tf.c_str(), limit);
+    string url = StringFormat("https://api.bybit.com/v5/market/kline?category=linear&symbol={}&interval={}&limit={}", symbol, tf, limit);
     if (since)
-        url += StringFormat("&start=%lld", since);
+        url += StringFormat("&start={}", since);
 
     string response = Axios::get(url);
     json j = json::parse(response);
@@ -391,9 +363,9 @@ RateData getBybitOHLCV(const string &symbol, const string &timeframe, int limit,
         tf = "D";
     }
 
-    string url = StringFormat("https://api.bybit.com/v5/market/kline?category=spot&symbol=%s&interval=%s&limit=%d", symbol.c_str(), tf.c_str(), limit);
+    string url = StringFormat("https://api.bybit.com/v5/market/kline?category=spot&symbol={}&interval={}&limit={}", symbol, tf, limit);
     if (since)
-        url += StringFormat("&start=%lld", since);
+        url += StringFormat("&start={}", since);
 
     string response = Axios::get(url);
     json j = json::parse(response);
@@ -437,11 +409,11 @@ RateData getOkxOHLCV(const string &symbol, const string &timeframe, int limit, l
     string url = "";
     if (since)
     {
-        url = StringFormat("https://www.okx.com/api/v5/market/history-candles?instId=%s&bar=%s&limit=%d&after=%lld", symbol.c_str(), tf.c_str(), limit, since + limit * timeframeToNumberMiliseconds(timeframe));
+        url = StringFormat("https://www.okx.com/api/v5/market/history-candles?instId={}&bar={}&limit={}&after={}", symbol, tf, limit, since + limit * timeframeToNumberMiliseconds(timeframe));
     }
     else
     {
-        url = StringFormat("https://www.okx.com/api/v5/market/candles?instId=%s&bar=%s&limit=%d", symbol.c_str(), tf.c_str(), limit);
+        url = StringFormat("https://www.okx.com/api/v5/market/candles?instId={}&bar={}&limit=%d", symbol, tf, limit);
     }
 
     string response = Axios::get(url);

--- a/botfather_c++/src/exchange/binance_future.cpp
+++ b/botfather_c++/src/exchange/binance_future.cpp
@@ -11,7 +11,7 @@ BinanceFuture::BinanceFuture(const string &apiKey, const string &secretKey)
 string BinanceFuture::buyMarket(const string &symbol, string quantity,
                                 string takeProfit, string stopLoss)
 {
-    string clientOrderId = StringFormat("BFBM%s%lld", symbol.c_str(), getCurrentTime());
+    string clientOrderId = StringFormat("BFBM{}{}", symbol, getCurrentTime());
     map<string, string> params = {
         {"recvWindow", "5000"},
         {"symbol", symbol},
@@ -44,7 +44,7 @@ string BinanceFuture::placeBuyMarketTPSL(const string &symbol, string &quantity,
         {
             json j = json::parse(resTP);
             tpID = j["clientOrderId"].get<string>();
-            LOGI("TP order id: %s", tpID.c_str());
+            LOGI("TP order id: {}", tpID);
         }
     }
     string slID;
@@ -56,7 +56,7 @@ string BinanceFuture::placeBuyMarketTPSL(const string &symbol, string &quantity,
             LOGI("Place SL error");
             if (!tpID.empty())
             {
-                LOGI("Cancel TP order %s", tpID.c_str());
+                LOGI("Cancel TP order {}", tpID);
                 cancelOrderByClientId(symbol, tpID);
             }
             LOGI("Close position");
@@ -66,7 +66,7 @@ string BinanceFuture::placeBuyMarketTPSL(const string &symbol, string &quantity,
         {
             json j = json::parse(resSL);
             slID = j["clientOrderId"].get<string>();
-            LOGI("SL order id: %s", slID.c_str());
+            LOGI("SL order id: {}", slID);
         }
     }
     if (!tpID.empty() && !slID.empty())
@@ -86,7 +86,7 @@ string BinanceFuture::placeBuyMarketTPSL(const string &symbol, string &quantity,
         }
         else
         {
-            LOGI("Insert order to database success %s %s %s", clientOrderId.c_str(), tpID.c_str(), slID.c_str());
+            LOGI("Insert order to database success {} {} {}", clientOrderId, tpID, slID);
         }
     }
     return resEntry;
@@ -94,7 +94,7 @@ string BinanceFuture::placeBuyMarketTPSL(const string &symbol, string &quantity,
 
 string BinanceFuture::sellMarket(const string &symbol, string quantity, string takeProfit, string stopLoss)
 {
-    string clientOrderId = StringFormat("BFSM%s%lld", symbol.c_str(), getCurrentTime());
+    string clientOrderId = StringFormat("BFSM{}{}", symbol, getCurrentTime());
     map<string, string> params = {
         {"recvWindow", "5000"},
         {"symbol", symbol},
@@ -126,7 +126,7 @@ string BinanceFuture::placeSellMarketTPSL(const string &symbol, string &quantity
         {
             json j = json::parse(resTP);
             tpID = j["clientOrderId"].get<string>();
-            LOGI("TP order id: %s", tpID.c_str());
+            LOGI("TP order id: {}", tpID);
         }
     }
 
@@ -139,7 +139,7 @@ string BinanceFuture::placeSellMarketTPSL(const string &symbol, string &quantity
             LOGI("Place SL error");
             if (!tpID.empty())
             {
-                LOGI("Cancel TP order %s", tpID.c_str());
+                LOGI("Cancel TP order {}", tpID);
                 cancelOrderByClientId(symbol, tpID);
             }
             LOGI("Close position");
@@ -149,7 +149,7 @@ string BinanceFuture::placeSellMarketTPSL(const string &symbol, string &quantity
         {
             json j = json::parse(resSL);
             slID = j["clientOrderId"].get<string>();
-            LOGI("SL order id: %s", slID.c_str());
+            LOGI("SL order id: {}", slID);
         }
     }
     if (!tpID.empty() && !slID.empty())
@@ -169,7 +169,7 @@ string BinanceFuture::placeSellMarketTPSL(const string &symbol, string &quantity
         }
         else
         {
-            LOGI("Insert order to database success %s %s %s", clientOrderId.c_str(), tpID.c_str(), slID.c_str());
+            LOGI("Insert order to database success {} {} {}", clientOrderId, tpID, slID);
         }
     }
     return resEntry;
@@ -177,7 +177,7 @@ string BinanceFuture::placeSellMarketTPSL(const string &symbol, string &quantity
 
 string BinanceFuture::buyLimit(const string &symbol, string quantity, string price, string takeProfit, string stopLoss, string expiredTime)
 {
-    string clientOrderId = StringFormat("BFBL%s%lld", symbol.c_str(), getCurrentTime());
+    string clientOrderId = StringFormat("BFBL{}{}", symbol, getCurrentTime());
     map<string, string> params = {
         {"recvWindow", "5000"},
         {"symbol", symbol},
@@ -222,7 +222,7 @@ string BinanceFuture::buyLimit(const string &symbol, string quantity, string pri
             string resCancel = cancelOrderByClientId(symbol, clientOrderId);
             if (resCancel == "")
             {
-                LOGI("Cancel order %s error", clientOrderId.c_str());
+                LOGI("Cancel order {} error", clientOrderId);
                 LOGI("Close position");
                 return sellMarket(symbol, quantity, "", "");
             }
@@ -232,7 +232,7 @@ string BinanceFuture::buyLimit(const string &symbol, string quantity, string pri
         {
             json j = json::parse(resTP);
             tpID = j["clientOrderId"].get<string>();
-            LOGI("TP order id: %s", tpID.c_str());
+            LOGI("TP order id: {}", tpID);
         }
     }
 
@@ -245,7 +245,7 @@ string BinanceFuture::buyLimit(const string &symbol, string quantity, string pri
             LOGI("Place SL error");
             if (!tpID.empty())
             {
-                LOGI("Cancel TP order %s", tpID.c_str());
+                LOGI("Cancel TP order {}", tpID);
                 cancelOrderByClientId(symbol, tpID);
             }
 
@@ -253,7 +253,7 @@ string BinanceFuture::buyLimit(const string &symbol, string quantity, string pri
             string resCancel = cancelOrderByClientId(symbol, clientOrderId);
             if (resCancel == "")
             {
-                LOGI("Cancel order %s error", clientOrderId.c_str());
+                LOGI("Cancel order {} error", clientOrderId);
                 return sellMarket(symbol, quantity, "", "");
             }
         }
@@ -261,7 +261,7 @@ string BinanceFuture::buyLimit(const string &symbol, string quantity, string pri
         {
             json j = json::parse(resSL);
             slID = j["clientOrderId"].get<string>();
-            LOGI("SL order id: %s", slID.c_str());
+            LOGI("SL order id: {}", slID);
         }
     }
 
@@ -282,7 +282,7 @@ string BinanceFuture::buyLimit(const string &symbol, string quantity, string pri
         }
         else
         {
-            LOGI("Insert order to database success %s %s %s", clientOrderId.c_str(), tpID.c_str(), slID.c_str());
+            LOGI("Insert order to database success {} {} {}", clientOrderId, tpID, slID);
         }
     }
 
@@ -291,7 +291,7 @@ string BinanceFuture::buyLimit(const string &symbol, string quantity, string pri
 
 string BinanceFuture::sellLimit(const string &symbol, string quantity, string price, string takeProfit, string stopLoss, string expiredTime)
 {
-    string clientOrderId = StringFormat("BFSL%s%lld", symbol.c_str(), getCurrentTime());
+    string clientOrderId = StringFormat("BFSL{}{}", symbol, getCurrentTime());
     map<string, string> params = {
         {"recvWindow", "5000"},
         {"symbol", symbol},
@@ -336,7 +336,7 @@ string BinanceFuture::sellLimit(const string &symbol, string quantity, string pr
             string resCancel = cancelOrderByClientId(symbol, clientOrderId);
             if (resCancel == "")
             {
-                LOGI("Cancel order %s error", clientOrderId.c_str());
+                LOGI("Cancel order {} error", clientOrderId);
                 LOGI("Close position");
                 return buyMarket(symbol, quantity, "", "");
             }
@@ -346,7 +346,7 @@ string BinanceFuture::sellLimit(const string &symbol, string quantity, string pr
         {
             json j = json::parse(resTP);
             tpID = j["clientOrderId"].get<string>();
-            LOGI("TP order id: %s", tpID.c_str());
+            LOGI("TP order id: {}", tpID);
         }
     }
 
@@ -359,7 +359,7 @@ string BinanceFuture::sellLimit(const string &symbol, string quantity, string pr
             LOGI("Place SL error");
             if (!tpID.empty())
             {
-                LOGI("Cancel TP order %s", tpID.c_str());
+                LOGI("Cancel TP order {}", tpID);
                 cancelOrderByClientId(symbol, tpID);
             }
 
@@ -367,7 +367,7 @@ string BinanceFuture::sellLimit(const string &symbol, string quantity, string pr
             string resCancel = cancelOrderByClientId(symbol, clientOrderId);
             if (resCancel == "")
             {
-                LOGI("Cancel order %s error", clientOrderId.c_str());
+                LOGI("Cancel order {} error", clientOrderId);
                 return buyMarket(symbol, quantity, "", "");
             }
         }
@@ -375,7 +375,7 @@ string BinanceFuture::sellLimit(const string &symbol, string quantity, string pr
         {
             json j = json::parse(resSL);
             slID = j["clientOrderId"].get<string>();
-            LOGI("SL order id: %s", slID.c_str());
+            LOGI("SL order id: {}", slID);
         }
     }
     if (!tpID.empty() && !slID.empty())
@@ -395,7 +395,7 @@ string BinanceFuture::sellLimit(const string &symbol, string quantity, string pr
         }
         else
         {
-            LOGI("Insert order to database success %s %s %s", clientOrderId.c_str(), tpID.c_str(), slID.c_str());
+            LOGI("Insert order to database success {} {} {}", clientOrderId, tpID, slID);
         }
     }
     return res;
@@ -404,8 +404,8 @@ string BinanceFuture::sellLimit(const string &symbol, string quantity, string pr
 string BinanceFuture::sendTPorSL(const string &symbol, const string &side, const string &type, string quantity, string stopPrice, string limitPrice)
 {
     string clientOrderId = (type == "TAKE_PROFIT_MARKET" || type == "STOP")
-                               ? StringFormat("BFTP%s%lld", symbol.c_str(), getCurrentTime())
-                               : StringFormat("BFSL%s%lld", symbol.c_str(), getCurrentTime());
+                               ? StringFormat("BFTP{}{}", symbol, getCurrentTime())
+                               : StringFormat("BFSL{}{}", symbol, getCurrentTime());
 
     map<string, string> params = {
         {"recvWindow", "5000"},
@@ -432,18 +432,18 @@ string BinanceFuture::sendOrder(const map<string, string> &params)
     string signature = sign(query);
     query += "&signature=" + signature;
 
-    string url = StringFormat("%s/fapi/v1/order?%s", BASE_URL.c_str(), query.c_str());
+    string url = StringFormat("{}/fapi/v1/order?{}", BASE_URL, query);
 
     try
     {
-        LOGI("Sending order to Binance Future: %s", url.c_str());
+        LOGI("Sending order to Binance Future: {}", url);
         string res = Axios::post(url, "", "application/json", {"X-MBX-APIKEY: " + apiKey});
-        LOGI("Response from Binance Future: %s", res.c_str());
+        LOGI("Response from Binance Future: {}", res);
         return res;
     }
     catch (const exception &e)
     {
-        LOGE("Error sending order to Binance Future: %s", e.what());
+        LOGE("Error sending order to Binance Future: {}", e.what());
         return "";
     }
 }
@@ -487,18 +487,18 @@ string BinanceFuture::cancelOrderByClientId(const string &symbol, const string &
     string signature = sign(query);
     query += "&signature=" + signature;
 
-    string url = StringFormat("%s/fapi/v1/order?%s", BASE_URL.c_str(), query.c_str());
+    string url = StringFormat("{}/fapi/v1/order?{}", BASE_URL, query);
 
     try
     {
-        LOGI("Cancelling order by client ID on Binance Future: %s", url.c_str());
+        LOGI("Cancelling order by client ID on Binance Future: {}", url);
         string res = Axios::del(url, {"X-MBX-APIKEY: " + apiKey});
-        LOGI("Response from Binance Future: %s", res.c_str());
+        LOGI("Response from Binance Future: {}", res);
         return res;
     }
     catch (const exception &e)
     {
-        LOGE("Error cancelling order by client ID on Binance Future: %s", e.what());
+        LOGE("Error cancelling order by client ID on Binance Future: {}", e.what());
         return "";
     }
 }
@@ -514,7 +514,7 @@ string BinanceFuture::getOrderStatus(const string &symbol, const string &orderId
     string signature = sign(query);
     query += "&signature=" + signature;
 
-    string url = StringFormat("%s/fapi/v1/order?%s", BASE_URL.c_str(), query.c_str());
+    string url = StringFormat("{}/fapi/v1/order?{}", BASE_URL, query);
 
     try
     {
@@ -523,7 +523,7 @@ string BinanceFuture::getOrderStatus(const string &symbol, const string &orderId
     }
     catch (const exception &e)
     {
-        LOGE("Error getting order status from Binance Future: %s", e.what());
+        LOGE("Error getting order status from Binance Future: {}", e.what());
         return "";
     }
 }

--- a/botfather_c++/src/exchange/order_monitor.cpp
+++ b/botfather_c++/src/exchange/order_monitor.cpp
@@ -43,7 +43,7 @@ static void checkOrderStatus()
 
                 if (entryStatus.empty() || tpStatus.empty() || slStatus.empty())
                 {
-                    LOGE("Failed to get order status for entryID: %s, tpID: %s, slID: %s", entryID.c_str(), tpID.c_str(), slID.c_str());
+                    LOGE("Failed to get order status for entryID: {}, tpID: {}, slID: {}", entryID, tpID, slID);
                     return;
                 }
 
@@ -57,7 +57,7 @@ static void checkOrderStatus()
 
                 if (entryStatus == "CANCELED" || tpStatus != "NEW" || slStatus != "NEW")
                 {
-                    LOGI("Cancel order. entryID=%s(%s), tpID=%s(%s), slID=%s(%s)", entryID.c_str(), entryStatus.c_str(), tpID.c_str(), tpStatus.c_str(), slID.c_str(), slStatus.c_str());
+                    LOGI("Cancel order. entryID={}({}), tpID={}({}), slID={}({})", entryID, entryStatus, tpID, tpStatus, slID, slStatus);
                     if (entryStatus == "NEW")
                     {
                         exchange->cancelOrderByClientId(symbol, entryID);
@@ -74,13 +74,13 @@ static void checkOrderStatus()
 
                 if (entryStatus != "NEW" && tpStatus != "NEW" || slStatus != "NEW")
                 {
-                    LOGI("Order %d is completed. entryID: %s, tpID: %s, slID: %s", id, entryID.c_str(), tpID.c_str(), slID.c_str());
+                    LOGI("Order {} is completed. entryID: {}, tpID: {}, slID: {}", id, entryID, tpID, slID);
                     db.executeUpdate("DELETE FROM RealOrders WHERE id = ?", {id});
                 }
             }
             catch (const exception err)
             {
-                LOGE("Exception in thread: %s", err.what());
+                LOGE("Exception in thread: {}", err.what());
             }
              semaphore.post(); });
     }

--- a/botfather_c++/src/mysql_connector.cpp
+++ b/botfather_c++/src/mysql_connector.cpp
@@ -14,11 +14,11 @@ MySQLConnector::MySQLConnector()
 
         initializePool(poolSize);
 
-        LOGI("MySQL connection pool initialized with %d connections", poolSize);
+        LOGI("MySQL connection pool initialized with {} connections", poolSize);
     }
     catch (sql::SQLException &e)
     {
-        LOGE("MySQL pool init failed: %s (SQLState: %s, ErrorCode: %d)",
+        LOGE("MySQL pool init failed: {} (SQLState: {}, ErrorCode: {})",
              e.what(), e.getSQLStateCStr(), e.getErrorCode());
     }
 }
@@ -144,7 +144,7 @@ int MySQLConnector::executeUpdate(const string &query, const vector<any> &params
     }
     catch (sql::SQLException &e)
     {
-        LOGE("MySQL error: %s (SQLState: %s, ErrorCode: %d)",
+        LOGE("MySQL error: {} (SQLState: {}, ErrorCode: {})",
              e.what(), e.getSQLStateCStr(), e.getErrorCode());
         return -1;
     }

--- a/botfather_c++/src/socket_server/socket_binance.cpp
+++ b/botfather_c++/src/socket_server/socket_binance.cpp
@@ -40,7 +40,7 @@ void SocketBinance::on_message(connection_hdl, message_ptr msg)
 
 void SocketBinance::connectSocket()
 {
-    LOGI("socket %s init %lu symbols", broker.c_str(), symbolList.size());
+    LOGI("socket {} init {} symbols", broker, symbolList.size());
 
     ws.set_access_channels(websocketpp::log::alevel::none);
     ws.clear_access_channels(websocketpp::log::alevel::all);
@@ -78,7 +78,7 @@ vector<string> SocketBinance::getSymbolList()
 RateData SocketBinance::getOHLCV(const string &symbol, const string &timeframe, int limit, long long since)
 {
     RateData rateData = getBinanceOHLCV(symbol, timeframe, limit, since);
-    LOGD("Get OHLCV %s:%s %s - %d items", broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)rateData.startTime.size());
+    LOGD("Get OHLCV {}:{} {} - {} items", broker, symbol, timeframe, rateData.startTime.size());
     return rateData;
 }
 

--- a/botfather_c++/src/socket_server/socket_binance_future.cpp
+++ b/botfather_c++/src/socket_server/socket_binance_future.cpp
@@ -40,7 +40,7 @@ void SocketBinanceFuture::on_message(connection_hdl, message_ptr msg)
 
 void SocketBinanceFuture::connectSocket()
 {
-    LOGI("socket %s init %lu symbols", broker.c_str(), symbolList.size());
+    LOGI("socket {} init {} symbols", broker, symbolList.size());
 
     ws.set_access_channels(websocketpp::log::alevel::none);
     ws.clear_access_channels(websocketpp::log::alevel::all);
@@ -77,7 +77,7 @@ vector<string> SocketBinanceFuture::getSymbolList()
 RateData SocketBinanceFuture::getOHLCV(const string &symbol, const string &timeframe, int limit, long long since)
 {
     RateData rateData = getBinanceFuturetOHLCV(symbol, timeframe, limit, since);
-    LOGD("Get OHLCV %s:%s %s - %d items", broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)rateData.startTime.size());
+    LOGD("Get OHLCV {}:{} {} - {} items", broker, symbol, timeframe, (int)rateData.startTime.size());
     return rateData;
 }
 

--- a/botfather_c++/src/socket_server/socket_bybit.cpp
+++ b/botfather_c++/src/socket_server/socket_bybit.cpp
@@ -21,7 +21,7 @@ void SocketBybit::on_message(connection_hdl, message_ptr msg)
     string type = j["type"].get<string>();
     if (type != "snapshot")
     {
-        LOGE("Invalid message type: %s", type.c_str());
+        LOGE("Invalid message type: {}", type);
         return;
     }
 
@@ -81,7 +81,7 @@ void SocketBybit::onSocketConnected(connection_hdl hdl)
 
 void SocketBybit::connectSocket()
 {
-    LOGI("socket %s init %lu symbols", broker.c_str(), symbolList.size());
+    LOGI("socket {} init {} symbols", broker, symbolList.size());
 
     ws.set_access_channels(websocketpp::log::alevel::none);
     ws.clear_access_channels(websocketpp::log::alevel::all);
@@ -111,7 +111,7 @@ vector<string> SocketBybit::getSymbolList()
 RateData SocketBybit::getOHLCV(const string &symbol, const string &timeframe, int limit, long long since)
 {
     RateData rateData = getBybitOHLCV(symbol, timeframe, limit, since);
-    LOGD("Get OHLCV %s:%s %s - %d items", broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)rateData.startTime.size());
+    LOGD("Get OHLCV {}:{} {} - {} items", broker, symbol, timeframe, rateData.startTime.size());
     return rateData;
 }
 

--- a/botfather_c++/src/socket_server/socket_bybit_future.cpp
+++ b/botfather_c++/src/socket_server/socket_bybit_future.cpp
@@ -21,7 +21,7 @@ void SocketBybitFuture::on_message(connection_hdl, message_ptr msg)
     string type = j["type"].get<string>();
     if (type != "snapshot")
     {
-        LOGE("Invalid message type: %s", type.c_str());
+        LOGE("Invalid message type: {}", type);
         return;
     }
 
@@ -81,7 +81,7 @@ void SocketBybitFuture::onSocketConnected(connection_hdl hdl)
 
 void SocketBybitFuture::connectSocket()
 {
-    LOGI("socket %s init %lu symbols", broker.c_str(), symbolList.size());
+    LOGI("socket {} init {} symbols", broker, symbolList.size());
 
     ws.set_access_channels(websocketpp::log::alevel::none);
     ws.clear_access_channels(websocketpp::log::alevel::all);
@@ -111,7 +111,7 @@ vector<string> SocketBybitFuture::getSymbolList()
 RateData SocketBybitFuture::getOHLCV(const string &symbol, const string &timeframe, int limit, long long since)
 {
     RateData rateData = getBybitFutureOHLCV(symbol, timeframe, limit, since);
-    LOGD("Get OHLCV %s:%s %s - %d items", broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)rateData.startTime.size());
+    LOGD("Get OHLCV {}:{} {} - {} items", broker, symbol, timeframe, (int)rateData.startTime.size());
     return rateData;
 }
 

--- a/botfather_c++/src/socket_server/socket_data.cpp
+++ b/botfather_c++/src/socket_server/socket_data.cpp
@@ -62,7 +62,7 @@ void SocketData::onCloseCandle(const string &symbol, string &timeframe, RateData
 
     if (digits.find(symbol) == digits.end())
     {
-        LOGE("No digit found for symbol %s:%s", broker.c_str(), symbol.c_str());
+        LOGE("No digit found for symbol {}:{}", broker, symbol);
         throw runtime_error("No digit found for symbol " + symbol);
     }
 
@@ -104,7 +104,7 @@ void SocketData::mergeData(RateData &rateData, const string &symbol, string &tim
     {
         // if (!ignoreClose)
         // {
-        //     LOGI("Force final %s %s %s", symbol.c_str(), timeframe.c_str(), toTimeString(rateStartTime).c_str());
+        //     LOGI("Force final {} {} {}", symbol, timeframe, toTimeString(rateStartTime));
         //     onCloseCandle(symbol, timeframe, rateData);
         // }
 
@@ -119,7 +119,7 @@ void SocketData::mergeData(RateData &rateData, const string &symbol, string &tim
     }
     else
     {
-        LOGI("Merge data fail %s:%s %s %s", broker.c_str(), symbol.c_str(), timeframe.c_str(), currentTF.c_str());
+        LOGI("Merge data fail {}:{} {} {}", broker, symbol, timeframe, currentTF);
     }
 }
 
@@ -171,10 +171,10 @@ void SocketData::updateCache(const RateData &rateData)
             
             if (!Redis::getInstance().pushBack(key, v))
             {
-                LOGE("Failed to update cache for %s:%s %s",broker.c_str(), symbol.c_str(), timeframe.c_str());
+                LOGE("Failed to update cache for {}:{} {}",broker, symbol, timeframe);
                 return;
             };
-            LOGD("Update cache %s %s %s - %d items",broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)v.size());
+            LOGD("Update cache {} {} {} - {} items",broker, symbol, timeframe, v.size());
         }
         else
         {
@@ -207,10 +207,10 @@ void SocketData::updateCache(const RateData &rateData)
             {
                 if (!Redis::getInstance().pushFront(key, v))
                 {
-                    LOGE("Failed to update cache for %s:%s %s",broker.c_str(),  symbol.c_str(), timeframe.c_str());
+                    LOGE("Failed to update cache for {}:{} {}",broker,  symbol, timeframe);
                     return;
                 }
-                LOGD("Update cache %s %s %s - %d items", broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)v.size());
+                LOGD("Update cache {} {} {} - {} items", broker, symbol, timeframe, v.size());
             }
         }
         while (Redis::getInstance().size(key) > MAX_CANDLE)
@@ -252,7 +252,7 @@ RateData SocketData::getOHLCVFromCache(const string &symbol, const string &timef
         vector<string> parts = split(item, '_');
         if (parts.size() != 6)
         {
-            LOGE("Invalid OHLCV data format: %s", item.c_str());
+            LOGE("Invalid OHLCV data format: {}", item);
             break;
         }
         rateData.startTime.push_back(stoll(parts[0]));
@@ -263,7 +263,7 @@ RateData SocketData::getOHLCVFromCache(const string &symbol, const string &timef
         rateData.volume.push_back(stod(parts[5]));
     }
 
-    LOGD("Get OHLCV from cache %s %s %s - %d items", broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)rateData.startTime.size());
+    LOGD("Get OHLCV from cache {} {} {} - {} items", broker, symbol, timeframe, rateData.startTime.size());
     return rateData;
 }
 
@@ -279,7 +279,7 @@ void SocketData::onSocketConnected(connection_hdl hdl)
     if (firstConnection)
     {
         firstConnection = false;
-        LOGI("Socket %s connected", broker.c_str());
+        LOGI("Socket {} connected", broker);
 
         thread t([this]()
                  {
@@ -344,7 +344,7 @@ void SocketData::onSocketConnected(connection_hdl hdl)
                                 }
                                 adjustData(rateData);
                                 if (!isValidData(rateData)) {
-                                    LOGE("Invalid data for %s:%s %s", broker.c_str(), symbol.c_str(), tf.c_str());
+                                    LOGE("Invalid data for {}:{} {}", broker, symbol, tf);
                                     rateData = getOHLCV(symbol, tf, MAX_CANDLE);
                                     cnt++;
                                     string key = broker + "_" + symbol + "_" + tf;
@@ -378,7 +378,7 @@ void SocketData::onSocketConnected(connection_hdl hdl)
                 }
             }
             
-            LOGD("%s: Init %d / %d. Get from cache %d times (%.1f%%)", broker.c_str(), end, (int) symbolList.size(), cnt, end * 100.0 / symbolList.size());
+            LOGD("{}: Init {} / {}. Get from cache {} times ({:.1f}%)", broker, end, symbolList.size(), cnt, end * 100.0 / symbolList.size());
 
             SLEEP_FOR(cnt * 5000 / 100 + 100);
         } });
@@ -387,7 +387,7 @@ void SocketData::onSocketConnected(connection_hdl hdl)
     }
     else
     {
-        LOGI("Socket %s reconnected", broker.c_str());
+        LOGI("Socket {} reconnected", broker);
     }
 }
 
@@ -397,7 +397,7 @@ void SocketData::reconnectSocket()
     WebSocket::connection_ptr con = ws.get_connection(uri, ec);
     if (ec)
     {
-        LOGE("Socket %s connect error: %s. uri=%s", broker.c_str(), ec.message().c_str(), uri.c_str());
+        LOGE("Socket {} connect error: {}. uri={}", broker, ec.message(), uri);
         SLEEP_FOR(3000);
         reconnectSocket();
         return;
@@ -408,13 +408,13 @@ void SocketData::reconnectSocket()
 
 void SocketData::onSocketClosed(connection_hdl hdl)
 {
-    LOGE("Socket %s closed.", broker.c_str());
+    LOGE("Socket {} closed.", broker);
     SLEEP_FOR(1000);
     reconnectSocket();
 }
 
 void SocketData::setBotList(shared_ptr<vector<shared_ptr<Bot>>> botList)
 {
-    LOGD("%s: Set bot list with size: %d", broker.c_str(), (int)botList->size());
+    LOGD("{}: Set bot list with size: {}", broker, botList->size());
     this->botList = botList;
 }

--- a/botfather_c++/src/socket_server/socket_okx.cpp
+++ b/botfather_c++/src/socket_server/socket_okx.cpp
@@ -73,7 +73,7 @@ void SocketOkx::onSocketConnected(connection_hdl hdl)
 
 void SocketOkx::connectSocket()
 {
-    LOGI("socket %s init %lu symbols", broker.c_str(), symbolList.size());
+    LOGI("socket {} init {} symbols", broker, symbolList.size());
 
     ws.set_access_channels(websocketpp::log::alevel::none);
     ws.clear_access_channels(websocketpp::log::alevel::all);
@@ -103,7 +103,7 @@ vector<string> SocketOkx::getSymbolList()
 RateData SocketOkx::getOHLCV(const string &symbol, const string &timeframe, int limit, long long since)
 {
     RateData rateData = getOkxOHLCV(symbol, timeframe, limit, since);
-    LOGD("Get OHLCV %s:%s %s - %d items", broker.c_str(), symbol.c_str(), timeframe.c_str(), (int)rateData.startTime.size());
+    LOGD("Get OHLCV {}:{} {} - {} items", broker, symbol, timeframe, rateData.startTime.size());
     return rateData;
 }
 

--- a/botfather_c++/src/worker.cpp
+++ b/botfather_c++/src/worker.cpp
@@ -39,7 +39,7 @@ static int binarySearch(const vector<Symbol> &symbolList, const string &symbol)
 
 void Worker::run()
 {
-    Timer timer(StringFormat("onCloseCandle %s %s %s", broker.c_str(), symbol.c_str(), timeframe.c_str()));
+    Timer timer(StringFormat("onCloseCandle {} {} {}", broker, symbol, timeframe));
     for (const shared_ptr<Bot> &bot : *botList)
     {
         try
@@ -57,7 +57,7 @@ void Worker::run()
         }
         catch (const exception &e)
         {
-            LOGE("Error in bot %s: %s", bot->botName.c_str(), e.what());
+            LOGE("Error in bot {}: {}", bot->botName, e.what());
             continue;
         }
     }
@@ -105,13 +105,13 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitStop == UNIT::PERCENT)
         {
-            expr = StringFormat("close() * (100 + abs(%s)) / 100", expr.c_str());
+            expr = StringFormat("close() * (100 + abs({})) / 100", expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate stop error. expr=%s", node.stop.c_str());
+            LOGE("Calculate stop error. expr={}", node.stop);
             return false;
         }
 
@@ -126,13 +126,13 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitStop == UNIT::PERCENT)
         {
-            expr = StringFormat("close() * (100 - abs(%s)) / 100", expr.c_str());
+            expr = StringFormat("close() * (100 - abs({})) / 100", expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate stop error. expr=%s", node.stop.c_str());
+            LOGE("Calculate stop error. expr={}", node.stop);
             return false;
         }
 
@@ -153,13 +153,13 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitEntry == UNIT::PERCENT)
         {
-            expr = StringFormat("close() * (100 - abs(%s)) / 100", expr.c_str());
+            expr = StringFormat("close() * (100 - abs({})) / 100", expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate entry error. expr=%s", node.entry.c_str());
+            LOGE("Calculate entry error. expr={}", node.entry);
             return false;
         }
 
@@ -174,13 +174,13 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitEntry == UNIT::PERCENT)
         {
-            expr = StringFormat("close() * (100 + abs(%s)) / 100", expr.c_str());
+            expr = StringFormat("close() * (100 + abs({})) / 100", expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate entry error. expr=%s", node.entry.c_str());
+            LOGE("Calculate entry error. expr={}", node.entry);
             return false;
         }
 
@@ -226,13 +226,13 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitSL == UNIT::PERCENT)
         {
-            expr = StringFormat("(%s) * (100 - abs(%s)) / 100", node.entry.c_str(), expr.c_str());
+            expr = StringFormat("({}) * (100 - abs({})) / 100", node.entry, expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate SL error. expr=%s", node.sl.c_str());
+            LOGE("Calculate SL error. expr={}", node.sl);
             return false;
         }
 
@@ -247,13 +247,13 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitSL == UNIT::PERCENT)
         {
-            expr = StringFormat("(%s) * (100 + abs(%s)) / 100", node.entry.c_str(), expr.c_str());
+            expr = StringFormat("({}) * (100 + abs({})) / 100", node.entry, expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate SL error. expr=%s", node.sl.c_str());
+            LOGE("Calculate SL error. expr={}", node.sl);
             return false;
         }
 
@@ -274,17 +274,17 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitTP == UNIT::PERCENT)
         {
-            expr = StringFormat("(%s) * (100 + abs(%s)) / 100", node.entry.c_str(), expr.c_str());
+            expr = StringFormat("({}) * (100 + abs({})) / 100", node.entry, expr);
         }
         else if (node.unitTP == UNIT::RR)
         {
-            expr = StringFormat("(%s + abs(%s - %s) * abs(%s))", node.entry.c_str(), node.entry.c_str(), node.sl.c_str(), expr.c_str());
+            expr = StringFormat("({} + abs({} - {}) * abs({}))", node.entry, node.entry, node.sl, expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate TP error. expr=%s", node.tp.c_str());
+            LOGE("Calculate TP error. expr={}", node.tp);
             return false;
         }
 
@@ -299,17 +299,17 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitTP == UNIT::PERCENT)
         {
-            expr = StringFormat("(%s) * (100 - abs(%s)) / 100", node.entry.c_str(), expr.c_str());
+            expr = StringFormat("({}) * (100 - abs({})) / 100", node.entry, expr);
         }
         else if (node.unitTP == UNIT::RR)
         {
-            expr = StringFormat("(%s - abs(%s - %s) * abs(%s))", node.entry.c_str(), node.entry.c_str(), node.sl.c_str(), expr.c_str());
+            expr = StringFormat("({} - abs({} - {}) * abs({}))", node.entry, node.entry, node.sl, expr);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate TP error. expr=%s", node.tp.c_str());
+            LOGE("Calculate TP error. expr={}", node.tp);
             return false;
         }
 
@@ -330,13 +330,13 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitVolume == UNIT::USD)
         {
-            expr = StringFormat("(%s) / %s", expr.c_str(), node.entry.c_str());
+            expr = StringFormat("({}) / {}", expr, node.entry);
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate volume error. expr=%s", node.volume.c_str());
+            LOGE("Calculate volume error. expr={}", node.volume);
             return false;
         }
 
@@ -357,17 +357,17 @@ bool Worker::adjustParam(NodeData &node)
         expr = calculateSub(expr);
         if (node.unitExpiredTime == UNIT::MINUTE)
         {
-            expr = StringFormat("((%s) * 60000) + %lld", expr.c_str(), nextTime(startTime[0], timeframe));
+            expr = StringFormat("(({}) * 60000) + {}", expr, nextTime(startTime[0], timeframe));
         }
         else if (node.unitExpiredTime == UNIT::CANDLE)
         {
-            expr = StringFormat("((%s) * 60000 * %d) + %lld", expr.c_str(), timeframeToNumberMinutes(timeframe), nextTime(startTime[0], timeframe));
+            expr = StringFormat("(({}) * 60000 * {}) + {}", expr, timeframeToNumberMinutes(timeframe), nextTime(startTime[0], timeframe));
         }
 
         any result = calculate(expr);
         if (!result.has_value() || result.type() != typeid(double))
         {
-            LOGE("Calculate expiredTime error. expr=%s", node.expiredTime.c_str());
+            LOGE("Calculate expiredTime error. expr={}", node.expiredTime);
             return false;
         }
 
@@ -434,7 +434,7 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
         }
         else
         {
-            LOGD("No result. symbol: %s:%s, timeframe: %s, expr=%s", broker.c_str(), symbol.c_str(), timeframe.c_str(), nodeData.value.c_str());
+            LOGD("No result. symbol: {}:{}, timeframe: {}, expr={}", broker, symbol, timeframe, nodeData.value);
             return false;
         }
     }
@@ -457,10 +457,10 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
             {"bybit_future", "https://www.bybit.com/trade/usdt/" + symbol}};
 
         string mess = emoji[broker];
-        mess += StringFormat("\n<a href='%s'><b>%s</b></a>", url[broker].c_str(), symbol.c_str());
-        mess += StringFormat("\n%s", broker.c_str());
-        mess += StringFormat("\n%s %s", timeframe.c_str(), toTimeString(startTime[0]).c_str());
-        mess += StringFormat("\n%s", content.c_str());
+        mess += StringFormat("\n<a href='{}'><b>{}</b></a>", url[broker], symbol);
+        mess += StringFormat("\n{}", broker);
+        mess += StringFormat("\n{} {}", timeframe, toTimeString(startTime[0]));
+        mess += StringFormat("\n{}", content);
 
         for (const string &id : bot.idTelegram)
         {
@@ -480,10 +480,10 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
 
     if (find(orderTypes.begin(), orderTypes.end(), node.type) != orderTypes.end())
     {
-        LOGI("New order - BotID: %d, Type: %s, Broker: %s, Symbol: %s, Timeframe: %s, Entry: %s, Stop: %s, TP: %s, SL: %s, Volume: %s, ExpiredTime: %s",
-             botID, node.type.c_str(), broker.c_str(), symbol.c_str(), timeframe.c_str(),
-             node.entry.c_str(), node.stop.c_str(), node.tp.c_str(), node.sl.c_str(),
-             node.volume.c_str(), node.expiredTime.c_str());
+        LOGI("New order - BotID: {}, Type: {}, Broker: {}, Symbol: {}, Timeframe: {}, Entry: {}, Stop: {}, TP: {}, SL: {}, Volume: {}, ExpiredTime: {}",
+             botID, node.type, broker, symbol, timeframe,
+             node.entry, node.stop, node.tp, node.sl,
+             node.volume, node.expiredTime);
 
         if (broker == "binance_future" && !bot.apiKey.empty() && !bot.secretKey.empty() && !bot.iv.empty())
         {
@@ -501,7 +501,7 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
                 }
                 else
                 {
-                    LOGE("Invalid TP or SL for BUY_MARKET order. TP: %s, SL: %s, Entry: %s", node.tp.c_str(), node.sl.c_str(), node.entry.c_str());
+                    LOGE("Invalid TP or SL for BUY_MARKET order. TP: {}, SL: {}, Entry: {}", node.tp, node.sl, node.entry);
                 }
             }
             else if (node.type == NODE_TYPE::BUY_LIMIT)
@@ -512,7 +512,7 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
                 }
                 else
                 {
-                    LOGE("Invalid TP or SL for BUY_LIMIT order. TP: %s, SL: %s, Entry: %s", node.tp.c_str(), node.sl.c_str(), node.entry.c_str());
+                    LOGE("Invalid TP or SL for BUY_LIMIT order. TP: {}, SL: {}, Entry: {}", node.tp, node.sl, node.entry);
                 }
             }
             else if (node.type == NODE_TYPE::SELL_MARKET)
@@ -523,7 +523,7 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
                 }
                 else
                 {
-                    LOGE("Invalid TP or SL for SELL_MARKET order. TP: %s, SL: %s, Entry: %s", node.tp.c_str(), node.sl.c_str(), node.entry.c_str());
+                    LOGE("Invalid TP or SL for SELL_MARKET order. TP: {}, SL: {}, Entry: {}", node.tp, node.sl, node.entry);
                 }
             }
             else if (node.type == NODE_TYPE::SELL_LIMIT)
@@ -534,7 +534,7 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
                 }
                 else
                 {
-                    LOGE("Invalid TP or SL for SELL_LIMIT order. TP: %s, SL: %s, Entry: %s", node.tp.c_str(), node.sl.c_str(), node.entry.c_str());
+                    LOGE("Invalid TP or SL for SELL_LIMIT order. TP: {}, SL: {}, Entry: {}", node.tp, node.sl, node.entry);
                 }
             }
         }


### PR DESCRIPTION
Replaces all printf-style logging macros and string formatting with spdlog and fmt library usage for improved type safety and flexibility. Adds spdlog as a dependency in CMake and updates build scripts. Initializes spdlog for file or console output based on build options. Removes legacy StringFormat implementation in favor of fmt::format-based templated function. Updates all log statements and string formatting throughout the codebase to use the new approach.