### PR TITLE
BF-41 funding rate realtime

### DIFF
--- a/botfather_c++/include/common/expr.h
+++ b/botfather_c++/include/common/expr.h
@@ -31,12 +31,13 @@ private:
     const double *close;
     const double *volume;
     long long *startTime;
+    double fundingRate;
 
 public:
     Expr(const string &broker, const string &symbol, const string &timeframe, int length,
          const double *open, const double *high, const double *low, const double *close, const double *volume,
-         long long *startTime)
-        : broker(broker), symbol(symbol), timeframe(timeframe), length(length), open(open), high(high), low(low), close(close), volume(volume), startTime(startTime)
+         long long *startTime, double fundingRate)
+        : broker(broker), symbol(symbol), timeframe(timeframe), length(length), open(open), high(high), low(low), close(close), volume(volume), startTime(startTime), fundingRate(fundingRate)
     {
     }
 
@@ -117,6 +118,7 @@ public:
 
     any visitHour(ExprParser::HourContext *ctx) override;
     any visitMinute(ExprParser::MinuteContext *ctx) override;
+    any visitFunding_rate(ExprParser::Funding_rateContext *ctx) override;
 
     // candlestick
     any visitBullish_engulfing(ExprParser::Bullish_engulfingContext *ctx) override;
@@ -128,8 +130,8 @@ public:
 
 any calculateExpr(const string &inputText, const string &broker, const string &symbol, const string &timeframe, int length,
                   const double *open, const double *high, const double *low, const double *close,
-                  const double *volume, long long *startTime);
+                  const double *volume, long long *startTime, double fundingRate);
 
 string calculateSubExpr(string &expr, const string &broker, const string &symbol, const string &timeframe, int length,
                         const double *open, const double *high, const double *low, const double *close,
-                        const double *volume, long long *startTime);
+                        const double *volume, long long *startTime, double fundingRate);

--- a/botfather_c++/include/socket_server/socket_data.h
+++ b/botfather_c++/include/socket_server/socket_data.h
@@ -14,6 +14,7 @@ protected:
     shared_ptr<vector<shared_ptr<Bot>>> botList;
     shared_ptr<boost::asio::ssl::context> on_tls_init(connection_hdl);
     unordered_map<string, Digit> digits;
+    unordered_map<string, double> fundingRates;
     bool firstConnection;
     string uri;
 

--- a/botfather_c++/include/worker.h
+++ b/botfather_c++/include/worker.h
@@ -16,6 +16,7 @@ private:
     shared_ptr<vector<shared_ptr<Bot>>> botList;
     unordered_map<string, bool> visited;
     Digit digit;
+    double fundingRate;
 
     string calculateSub(string &expr);
     any calculate(string &expr);
@@ -23,7 +24,7 @@ private:
     int compareStringNumber(const string &a, const string &b);
 
 public:
-    Worker(shared_ptr<vector<shared_ptr<Bot>>> botList, string broker, string symbol, string timeframe, vector<double> open, vector<double> high, vector<double> low, vector<double> close, vector<double> volume, vector<long long> startTime, Digit digit);
+    Worker(shared_ptr<vector<shared_ptr<Bot>>> botList, string broker, string symbol, string timeframe, vector<double> open, vector<double> high, vector<double> low, vector<double> close, vector<double> volume, vector<long long> startTime, Digit digit, double fundingRate);
     void run();
     void dfs_handleLogic(Route &route, Bot &bot);
     bool handleLogic(NodeData &node, Bot &bot);

--- a/botfather_c++/src/common/expr.cpp
+++ b/botfather_c++/src/common/expr.cpp
@@ -857,6 +857,11 @@ any Expr::visitMinute(ExprParser::MinuteContext *ctx)
     return minute;
 }
 
+any Expr::visitFunding_rate(ExprParser::Funding_rateContext *ctx)
+{
+    return fundingRate;
+}
+
 any Expr::visitBullish_engulfing(ExprParser::Bullish_engulfingContext *ctx)
 {
     auto args = ctx->INT();
@@ -995,19 +1000,18 @@ CachedParseTree &getParseTree(const string &key)
 
 any calculateExpr(const string &inputText, const string &broker, const string &symbol, const string &timeframe, int length,
                   const double *open, const double *high, const double *low, const double *close,
-                  const double *volume, long long *startTime)
+                  const double *volume, long long *startTime, double fundingRate)
 {
     const std::string key = toLowerCase(inputText);
     auto &entry = getParseTree(key);
 
-    Expr expr(broker, symbol, timeframe, length, open, high, low, close, volume, startTime);
-
+    Expr expr(broker, symbol, timeframe, length, open, high, low, close, volume, startTime, fundingRate);
     return expr.visit(entry.tree);
 }
 
 string calculateSubExpr(string &expr, const string &broker, const string &symbol, const string &timeframe, int length,
                         const double *open, const double *high, const double *low, const double *close,
-                        const double *volume, long long *startTime)
+                        const double *volume, long long *startTime, double fundingRate)
 {
     stack<string> st;
     string s;
@@ -1027,7 +1031,7 @@ string calculateSubExpr(string &expr, const string &broker, const string &symbol
             }
             string lastS = st.top();
             st.pop();
-            any result = calculateExpr(s, broker, symbol, timeframe, length, open, high, low, close, volume, startTime);
+            any result = calculateExpr(s, broker, symbol, timeframe, length, open, high, low, close, volume, startTime, fundingRate);
             s = lastS + " ";
             if (result.type() == typeid(double))
             {

--- a/botfather_c++/src/socket_server/socket_binance_future.cpp
+++ b/botfather_c++/src/socket_server/socket_binance_future.cpp
@@ -12,29 +12,55 @@ void SocketBinanceFuture::on_message(connection_hdl, message_ptr msg)
     const string message = msg->get_payload();
     json j = json::parse(message);
     // {"stream":"slfusdt@kline_1m","data":{"e":"kline","E":1745689546800,"s":"SLFUSDT","k":{"t":1745689500000,"T":1745689559999,"s":"SLFUSDT","i":"1m","f":13562205,"L":13562210,"o":"0.20800000","c":"0.20810000","h":"0.20810000","l":"0.20800000","v":"624.60000000","n":6,"x":false,"q":"129.95848000","V":"624.60000000","Q":"129.95848000","B":"0"}}}
+
+    // {"stream":"!markPrice@arr",
+    //  "data": {
+    //     "e": "markPriceUpdate",  	// Event type
+    //     "E": 1562305380000,      	// Event time
+    //     "s": "BTCUSDT",          	// Symbol
+    //     "p": "11185.87786614",   	// Mark price
+    //     "i": "11784.62659091"		// Index price
+    //     "P": "11784.25641265",		// Estimated Settle Price, only useful in the last hour before the settlement starts
+    //     "r": "0.00030000",       	// Funding rate
+    //     "T": 1562306400000       	// Next funding time
+    //  }}
+
     auto jdata = j["data"];
-    auto kline = jdata["k"];
-
-    string symbol = jdata["s"].get<string>();
-    string interval = kline["i"].get<string>();
-    long long startTime = kline["t"].get<long long>();
-    double open = stod(kline["o"].get<string>());
-    double high = stod(kline["h"].get<string>());
-    double low = stod(kline["l"].get<string>());
-    double close = stod(kline["c"].get<string>());
-    double volume = stod(kline["v"].get<string>());
-    bool isFinal = kline["x"].get<bool>();
-
-    for (auto tf : timeframes)
+    auto jstream = j["stream"];
+    if (jstream == "!markPrice@arr")
     {
         lock_guard<mutex> lock(mMutex);
+        for (const auto &item : jdata)
+        {
+            string symbol = item["s"].get<string>();
+            fundingRates[symbol] = stod(item["P"].get<string>()) * 100.0;
+        }
+    }
+    else
+    {
+        auto kline = jdata["k"];
 
-        string key = symbol + "_" + tf;
-        RateData &rateData = data[key];
-        if (rateData.startTime.empty())
-            continue;
+        string symbol = jdata["s"].get<string>();
+        string interval = kline["i"].get<string>();
+        long long startTime = kline["t"].get<long long>();
+        double open = stod(kline["o"].get<string>());
+        double high = stod(kline["h"].get<string>());
+        double low = stod(kline["l"].get<string>());
+        double close = stod(kline["c"].get<string>());
+        double volume = stod(kline["v"].get<string>());
+        bool isFinal = kline["x"].get<bool>();
 
-        mergeData(rateData, symbol, tf, interval, open, high, low, close, volume, startTime, isFinal, false);
+        for (auto tf : timeframes)
+        {
+            lock_guard<mutex> lock(mMutex);
+
+            string key = symbol + "_" + tf;
+            RateData &rateData = data[key];
+            if (rateData.startTime.empty())
+                continue;
+
+            mergeData(rateData, symbol, tf, interval, open, high, low, close, volume, startTime, isFinal, false);
+        }
     }
 }
 
@@ -53,10 +79,10 @@ void SocketBinanceFuture::connectSocket()
                                 placeholders::_2));
     ws.set_tls_init_handler(bind(&SocketBinanceFuture::on_tls_init, this, placeholders::_1));
     ws.set_open_handler(bind(&SocketBinanceFuture::onSocketConnected, this, placeholders::_1));
-    ws.set_close_handler(bind(&SocketBinanceFuture::onSocketClosed, this, std::placeholders::_1));
-    ws.set_fail_handler(bind(&SocketBinanceFuture::onSocketClosed, this, std::placeholders::_1));
+    ws.set_close_handler(bind(&SocketBinanceFuture::onSocketClosed, this, placeholders::_1));
+    ws.set_fail_handler(bind(&SocketBinanceFuture::onSocketClosed, this, placeholders::_1));
 
-    uri = "wss://fstream.binance.com/stream?streams=";
+    uri = "wss://fstream.binance.com/stream?streams=!markPrice@arr/";
     for (int i = 0; i < symbolList.size(); i++)
     {
         uri += (toLowerCase(symbolList[i]) + "@kline_1m");

--- a/botfather_c++/src/socket_server/socket_bybit.cpp
+++ b/botfather_c++/src/socket_server/socket_bybit.cpp
@@ -21,7 +21,7 @@ void SocketBybit::on_message(connection_hdl, message_ptr msg)
     string type = j["type"].get<string>();
     if (type != "snapshot")
     {
-        LOGE("Invalid message type: {}", type);
+        LOGE("Invalid message type: {}. message: {}", type, message);
         return;
     }
 

--- a/botfather_c++/src/socket_server/socket_bybit_future.cpp
+++ b/botfather_c++/src/socket_server/socket_bybit_future.cpp
@@ -12,46 +12,62 @@ void SocketBybitFuture::on_message(connection_hdl, message_ptr msg)
     const string message = msg->get_payload();
     json j = json::parse(message);
     // "{\"topic\":\"kline.1.1000000BABYDOGEUSDT\",\"data\":[{\"start\":1751739720000,\"end\":1751739779999,\"interval\":\"1\",\"open\":\"0.0011086\",\"close\":\"0.00111\",\"high\":\"0.00111\",\"low\":\"0.001108\",\"volume\":\"3509500\",\"turnover\":\"3889.88484\",\"confirm\":false,\"timestamp\":1751739741199}],\"ts\":1751739741199,\"type\":\"snapshot\"}"
-
+    // "{\"topic\":\"tickers.1000000BABYDOGEUSDT\",\"type\":\"snapshot\",\"data\":{\"symbol\":\"1000000BABYDOGEUSDT\",\"tickDirection\":\"ZeroMinusTick\",\"price24hPcnt\":\"-0.039941\",\"lastPrice\":\"0.0014470\",\"prevPrice24h\":\"0.0015072\",\"highPrice24h\":\"0.0015271\",\"lowPrice24h\":\"0.0014362\",\"prevPrice1h\":\"0.0014534\",\"markPrice\":\"0.0014470\",\"indexPrice\":\"0.0014453\",\"openInterest\":\"2319587000\",\"openInterestValue\":\"3356442.39\",\"turnover24h\":\"3790950.2832\",\"volume24h\":\"2566119900.0000\",\"nextFundingTime\":\"1752955200000\",\"fundingRate\":\"0.00005\",\"bid1Price\":\"0.0014464\",\"bid1Size\":\"36600\",\"ask1Price\":\"0.0014467\",\"ask1Size\":\"6000\",\"preOpenPrice\":\"\",\"preQty\":\"\",\"curPreListingPhase\":\"\"},\"cs\":72344544468,\"ts\":1752941629545}"
+    // "{\"topic\":\"tickers.1000000BABYDOGEUSDT\",\"type\":\"delta\",\"data\":{\"symbol\":\"1000000BABYDOGEUSDT\",\"bid1Price\":\"0.0014553\",\"bid1Size\":\"39200\",\"ask1Price\":\"0.0014561\",\"ask1Size\":\"10400\"},\"cs\":72346359155,\"ts\":1752942199745}"
     if (!j.contains("type") || !j.contains("topic") || !j.contains("data"))
     {
         return;
     }
 
+    vector<string> topic = split(j["topic"].get<string>(), '.');
+    string stream = topic[0];
+
     string type = j["type"].get<string>();
-    if (type != "snapshot")
+    if (type != "snapshot" && stream != "tickers")
     {
-        LOGE("Invalid message type: {}", type);
+        LOGE("Invalid message type: {}. message: {}", type, message);
         return;
     }
 
-    vector<string> topic = split(j["topic"].get<string>(), '.');
     json jData = j["data"];
-    string symbol = topic[2];
 
-    for (json &candle : jData)
+    if (stream == "tickers")
     {
-        string interval = candle["interval"].get<string>();
-        interval.push_back('m'); // Ensure interval is in minutes format
-
-        long long startTime = candle["start"].get<long long>();
-        double open = stod(candle["open"].get<string>());
-        double high = stod(candle["high"].get<string>());
-        double low = stod(candle["low"].get<string>());
-        double close = stod(candle["close"].get<string>());
-        double volume = stod(candle["volume"].get<string>());
-        bool isFinal = candle["confirm"].get<bool>();
-
-        for (auto tf : timeframes)
+        if (jData.contains("fundingRate"))
         {
+            string symbol = jData["symbol"].get<string>();
             lock_guard<mutex> lock(mMutex);
+            fundingRates[symbol] = stod(jData["fundingRate"].get<string>()) * 100.0;
+        }
+    }
+    else
+    {
+        string symbol = topic[2];
 
-            string key = symbol + "_" + tf;
-            RateData &rateData = data[key];
-            if (rateData.startTime.empty())
-                continue;
+        for (json &candle : jData)
+        {
+            string interval = candle["interval"].get<string>();
+            interval.push_back('m'); // Ensure interval is in minutes format
 
-            mergeData(rateData, symbol, tf, interval, open, high, low, close, volume, startTime, isFinal, false);
+            long long startTime = candle["start"].get<long long>();
+            double open = stod(candle["open"].get<string>());
+            double high = stod(candle["high"].get<string>());
+            double low = stod(candle["low"].get<string>());
+            double close = stod(candle["close"].get<string>());
+            double volume = stod(candle["volume"].get<string>());
+            bool isFinal = candle["confirm"].get<bool>();
+
+            for (auto tf : timeframes)
+            {
+                lock_guard<mutex> lock(mMutex);
+
+                string key = symbol + "_" + tf;
+                RateData &rateData = data[key];
+                if (rateData.startTime.empty())
+                    continue;
+
+                mergeData(rateData, symbol, tf, interval, open, high, low, close, volume, startTime, isFinal, false);
+            }
         }
     }
 }
@@ -60,11 +76,12 @@ void SocketBybitFuture::onSocketConnected(connection_hdl hdl)
 {
     for (size_t i = 0; i < symbolList.size(); i += 10)
     {
-        std::vector<std::string> args;
+        vector<string> args;
 
         for (size_t j = i; j < i + 10 && j < symbolList.size(); ++j)
         {
             args.push_back("kline.1." + symbolList[j]);
+            args.push_back("tickers." + symbolList[j]);
         }
 
         json payload = {
@@ -94,8 +111,8 @@ void SocketBybitFuture::connectSocket()
                                 placeholders::_2));
     ws.set_tls_init_handler(bind(&SocketBybitFuture::on_tls_init, this, placeholders::_1));
     ws.set_open_handler(bind(&SocketBybitFuture::onSocketConnected, this, placeholders::_1));
-    ws.set_close_handler(bind(&SocketBybitFuture::onSocketClosed, this, std::placeholders::_1));
-    ws.set_fail_handler(bind(&SocketBybitFuture::onSocketClosed, this, std::placeholders::_1));
+    ws.set_close_handler(bind(&SocketBybitFuture::onSocketClosed, this, placeholders::_1));
+    ws.set_fail_handler(bind(&SocketBybitFuture::onSocketClosed, this, placeholders::_1));
 
     uri = "wss://stream.bybit.com/v5/public/linear";
 
@@ -115,6 +132,7 @@ RateData SocketBybitFuture::getOHLCV(const string &symbol, const string &timefra
     return rateData;
 }
 
-unordered_map<string, Digit> SocketBybitFuture::getDigit() {
+unordered_map<string, Digit> SocketBybitFuture::getDigit()
+{
     return getBybitFutureDigits();
 }

--- a/botfather_c++/src/socket_server/socket_data.cpp
+++ b/botfather_c++/src/socket_server/socket_data.cpp
@@ -36,6 +36,7 @@ void SocketData::init()
                 data[key].symbol = symbol;
                 data[key].interval = tf;
             }
+            fundingRates[symbol] = 0;
         }
     }
 
@@ -66,7 +67,7 @@ void SocketData::onCloseCandle(const string &symbol, string &timeframe, RateData
         throw runtime_error("No digit found for symbol " + symbol);
     }
 
-    shared_ptr<Worker> worker = make_shared<Worker>(botList, broker, symbol, timeframe, move(open), move(high), move(low), move(close), move(volume), move(startTime), digits[symbol]);
+    shared_ptr<Worker> worker = make_shared<Worker>(botList, broker, symbol, timeframe, move(open), move(high), move(low), move(close), move(volume), move(startTime), digits[symbol], fundingRates[symbol]);
 
     task.run([worker, this, timeframe]()
              { worker->run(); });

--- a/botfather_c++/src/worker.cpp
+++ b/botfather_c++/src/worker.cpp
@@ -10,8 +10,8 @@
 
 static vector<string> orderTypes = {NODE_TYPE::BUY_MARKET, NODE_TYPE::BUY_LIMIT, NODE_TYPE::BUY_STOP_MARKET, NODE_TYPE::BUY_STOP_LIMIT, NODE_TYPE::SELL_MARKET, NODE_TYPE::SELL_LIMIT, NODE_TYPE::SELL_STOP_MARKET, NODE_TYPE::SELL_STOP_LIMIT};
 
-Worker::Worker(shared_ptr<vector<shared_ptr<Bot>>> botList, string broker, string symbol, string timeframe, vector<double> open, vector<double> high, vector<double> low, vector<double> close, vector<double> volume, vector<long long> startTime, Digit digit)
-    : botList(botList), broker(move(broker)), symbol(move(symbol)), timeframe(move(timeframe)), open(move(open)), high(move(high)), low(move(low)), close(move(close)), volume(move(volume)), startTime(move(startTime)), digit(digit) {};
+Worker::Worker(shared_ptr<vector<shared_ptr<Bot>>> botList, string broker, string symbol, string timeframe, vector<double> open, vector<double> high, vector<double> low, vector<double> close, vector<double> volume, vector<long long> startTime, Digit digit, double fundingRate)
+    : botList(botList), broker(move(broker)), symbol(move(symbol)), timeframe(move(timeframe)), open(move(open)), high(move(high)), low(move(low)), close(move(close)), volume(move(volume)), startTime(move(startTime)), digit(digit), fundingRate(fundingRate) {};
 
 static int binarySearch(const vector<Symbol> &symbolList, const string &symbol)
 {
@@ -83,14 +83,14 @@ string Worker::calculateSub(string &expr)
 {
     return calculateSubExpr(expr, broker, symbol, timeframe, open.size(),
                             open.data(), high.data(), low.data(), close.data(), volume.data(),
-                            startTime.data());
+                            startTime.data(), fundingRate);
 }
 
 any Worker::calculate(string &expr)
 {
     return calculateExpr(expr, broker, symbol, timeframe, open.size(),
                          open.data(), high.data(), low.data(), close.data(), volume.data(),
-                         startTime.data());
+                         startTime.data(), fundingRate);
 }
 
 bool Worker::adjustParam(NodeData &node)
@@ -410,7 +410,7 @@ bool Worker::handleLogic(NodeData &nodeData, Bot &bot)
     {
         any result = calculateExpr(nodeData.value, broker, symbol, timeframe, open.size(),
                                    open.data(), high.data(), low.data(), close.data(), volume.data(),
-                                   startTime.data());
+                                   startTime.data(), fundingRate);
 
         if (result.has_value())
         {

--- a/front-end/src/components/ExprInput/CompletionList.ts
+++ b/front-end/src/components/ExprInput/CompletionList.ts
@@ -68,6 +68,18 @@ export default [
     },
     {
         type: 'function',
+        label: 'funding_rate',
+        detail: '()',
+        apply: 'funding_rate()',
+        boost: 0,
+        info: ` - Giá trị funding rate hiện tại (%)
+                - Spot có funding rate = 0
+                Ví dụ:
+                + funding_rate() = 0.01
+                `
+    },
+    {
+        type: 'function',
         label: 'open',
         detail: '(i)',
         apply: 'open(0)',

--- a/src/common/Expr.g4
+++ b/src/common/Expr.g4
@@ -70,6 +70,7 @@ expr
     | max_ampl                  # iMaxAmpl
     | min_amplP                 # iMinAmplP
     | max_amplP                 # iMaxAmplP
+    | funding_rate              # iFundingRate
     ;
 
 hour: 'hour' '(' ')';
@@ -129,6 +130,7 @@ min_ampl: 'min_ampl' '(' INT (',' INT)? ')';
 max_ampl: 'max_ampl' '(' INT (',' INT)? ')';
 min_amplP: 'min_ampl%' '(' INT (',' INT)? ')';
 max_amplP: 'max_ampl%' '(' INT (',' INT)? ')';
+funding_rate: 'funding_rate' '(' ')';
 
 comparisonOp
     : '>'


### PR DESCRIPTION
Introduces support for a funding_rate() function in the expression parser and evaluation engine, allowing access to the current funding rate (in %) for supported symbols. Updates socket data handlers to track and provide funding rates from Binance and Bybit futures streams, and propagates funding rate values through the worker and expression evaluation pipeline. Also updates the frontend completion list and grammar to document and enable the new function.