### PR TITLE
Handle partial fills on canceled orders

### DIFF
--- a/botfather_c++/src/exchange/binance_future.cpp
+++ b/botfather_c++/src/exchange/binance_future.cpp
@@ -630,7 +630,7 @@ string BinanceFuture::cancelOrderByClientId(const string &symbol, const string &
             {
                 LOGE("order partially filled {}. Try to close position", stod(executedQty));
                 string side = j["side"].get<string>();
-                string result = side == BUY ? sellMarket(symbol, executedQty, "", "", true) : buyMarket(symbol, executedQty, "", "", true);
+                string result = (side == BUY) ? sellMarket(symbol, executedQty, "", "", true) : buyMarket(symbol, executedQty, "", "", true);
                 LOGI("Response from Binance Future: {}", result);
                 return result;
             }

--- a/botfather_c++/src/exchange/order_monitor.cpp
+++ b/botfather_c++/src/exchange/order_monitor.cpp
@@ -104,6 +104,19 @@ static void checkOrderStatus()
                 if (entryStatus != "NEW" && (tpStatus != "NEW" || slStatus != "NEW"))
                 {
                     LOGI("Order {} is completed. entryID: {}, tpID: {}, slID: {}", id, entryID, tpID, slID);
+
+                    if (entryStatus == "CANCELED")
+                    {
+                        double executedQty = entryJson["executedQty"].get<double>();
+                        if (executedQty > 0)
+                        {
+                            LOGE("Order {} is partially filled. Try to close position", entryJson.dump());
+                            string side = entryJson["side"].get<string>();
+                            string result = (side == "BUY") ? exchange->sellMarket(symbol, to_string(executedQty), "", "", true) : exchange->buyMarket(symbol, to_string(executedQty), "", "", true);
+                            LOGI("Response from Binance Future: {}", result);
+                        }
+                    }
+
                     db.executeUpdate("DELETE FROM RealOrders WHERE id = ?", {id});
                 }
             }


### PR DESCRIPTION
Added logic to detect and close positions for partially filled orders when an order is canceled in order_monitor.cpp. Also updated binance_future.cpp to clarify conditional logic for closing positions based on order side.